### PR TITLE
fix(ui): add data-lpignore to honeypot fields

### DIFF
--- a/webserver/web/templates/auth/login.html.tera
+++ b/webserver/web/templates/auth/login.html.tera
@@ -91,7 +91,7 @@
   <div class="field {{ honeypot.class }}">
     <div class="control">
       <label class="label">{{ tr(_langs=langs, _msg="antispam-honeypot", _attr="email") }}</label>
-      <input tabindex="-1" aria-hidden="true" name="email" class="input" type="text" autocomplete="off"/>
+      <input tabindex="-1" aria-hidden="true" name="email" class="input" type="text" autocomplete="off" data-lpignore="true"/>
     </div>
   </div>
 

--- a/webserver/web/templates/auth/register.html.tera
+++ b/webserver/web/templates/auth/register.html.tera
@@ -68,7 +68,7 @@
   <div class="field {{ honeypot.class }}">
     <div class="control">
       <label class="label">{{ tr(_langs=langs, _msg="antispam-honeypot", _attr="title") }}</label>
-      <input tabindex="-1" aria-hidden="true" name="title" class="input" type="text" autocomplete="off"/>
+      <input tabindex="-1" aria-hidden="true" name="title" class="input" type="text" autocomplete="off" data-lpignore="true"/>
     </div>
   </div>
 

--- a/webserver/web/templates/index.html.tera
+++ b/webserver/web/templates/index.html.tera
@@ -233,7 +233,7 @@ New
 
   <div class="control {{ honeypot.class }}">
     <label class="label">{{ tr(_langs=langs, _msg="antispam-honeypot", _attr="email") }}</label>
-    <input tabindex="-1" aria-hidden="true" name="email" class="input" type="text" autocomplete="off"/>
+    <input tabindex="-1" aria-hidden="true" name="email" class="input" type="text" autocomplete="off" data-lpignore="true"/>
   </div>
 
   <div class="paste-submit-buttons">


### PR DESCRIPTION
This is because LastPass is determined to ignore all the other hints that exist telling password managers to ignore this field.